### PR TITLE
test-7: authorization

### DIFF
--- a/authorization-service/.env
+++ b/authorization-service/.env
@@ -1,0 +1,1 @@
+testuser=testpass

--- a/authorization-service/handlers/basicAuthorizer.js
+++ b/authorization-service/handlers/basicAuthorizer.js
@@ -1,0 +1,40 @@
+// const { Buffer } = require('node:buffer');
+const generatePolicy = (principalId, Resource, Effect) => ({
+  principalId,
+  policyDocument: {
+    Version: '2012-10-17',
+    Statement: {
+      Action: 'execute-api:Invoke',
+      Effect,
+      Resource,
+    },
+  },
+});
+
+module.exports.basicAuthorizer = async (event, _context, cb) => {
+  console.log('event', event);
+  if (event.type !== 'TOKEN') {
+   cb('Unauthorized');
+  }
+  try {
+    const { authorizationToken } = event;
+    console.log(authorizationToken);
+    const encodedCreds = authorizationToken.split(' ')[1];
+    const buff = Buffer.from(encodedCreds, 'base64');
+    const plainCreds = buff.toString('utf-8').split(':');
+    const [username, password] = plainCreds;
+    console.log('username', username);
+    console.log('password', password);
+    const storedUserPassword = process.env[username];
+    console.log('storedUserPassword', storedUserPassword);
+    const effect = !storedUserPassword || storedUserPassword !== password ? 'Deny' : 'Allow';
+    console.log('effect', effect);
+    const policy = generatePolicy(encodedCreds, event.methodArn, effect);
+    console.log('policy', policy);
+
+    cb(null, policy);
+  }
+  catch ( err ) {
+    cb('Unauthorized');
+  }
+}

--- a/authorization-service/package.json
+++ b/authorization-service/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "import service",
+  "version": "1.0.0",
+  "description": "Import products service",
+  "engines": {
+    "node": ">=14.15.0"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.1238.0"
+  },
+  "devDependencies": {
+    "jest": "^29.1.2",
+    "serverless": "^3.0.0",
+    "serverless-dotenv-plugin": "^4.0.2",
+    "serverless-esbuild": "^1.23.3"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "author": "The serverless webpack authors (https://github.com/elastic-coders/serverless-webpack)",
+  "license": "MIT"
+}

--- a/authorization-service/serverless.yml
+++ b/authorization-service/serverless.yml
@@ -1,0 +1,14 @@
+service: authorization-service
+frameworkVersion: '3'
+
+provider:
+  name: aws
+  runtime: nodejs12.x
+  stage: dev
+  region: eu-west-1
+plugins:
+  - serverless-dotenv-plugin
+functions:
+  basicAuthorizer:
+    handler: handlers/basicAuthorizer.basicAuthorizer
+

--- a/import-service/serverless.yml
+++ b/import-service/serverless.yml
@@ -68,6 +68,12 @@ functions:
             parameters:
               querystrings:
                 name: true
+          authorizer:
+            name: basicAuthorizer
+            arn: "arn:aws:lambda:eu-west-1:007756198797:function:authorization-service-dev-basicAuthorizer"
+            resultTtlInSeconds: 0
+            identitySource: method.request.header.Authorization
+            type: token
   importFileParser:
     handler: handlers/importFileParser.importFileParser
     environment:


### PR DESCRIPTION
1 - authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
 3 - Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
 5 - Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)

Shop URL https://d12yx7bq9xds9s.cloudfront.net/admin/products

